### PR TITLE
fix: the "data" argument must be of type string by converting ppid nu…

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ function ppidChanged(filename) {
         `${tmpdir() + sep + process.cwd().split(sep).pop()}-${checksum(process.cwd())}.pid`
     
     const lastPpid = fs.existsSync(path) && fs.readFileSync(path, 'utf8')
-    fs.writeFileSync(path, process.ppid, 'utf8')
+    let ppid = process.ppid
+    if (typeof ppid == 'number') {
+      ppid = ppid.toString()
+    }
+    fs.writeFileSync(path, ppid, 'utf8')
     return lastPpid != process.ppid ? lastPpid : false
 }
 


### PR DESCRIPTION
According to Nodejs documentation

1. `fs.writeFileSync(file, data[, options])` doesn't allow `number` data type for `data` argument, please refer to https://nodejs.org/api/fs.html#fs_fs_writefilesync_file_data_options
2. `process.ppid` is always returning an `integer` data type, please refer to https://nodejs.org/api/process.html#process_process_ppid

Basically, this PR will convert the `ppid` to string to fix the error throw from `fs.writeFileSync`